### PR TITLE
Set a default value for getMeta() if nothing found

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ Then use like this:
 $model = SomeModel::find(1);
 $model->getAllMeta();
 $model->getMeta('some_key');
+// You may also specify a default return value
+$model->getMeta('doesnt_exist', 'Default Value');
 $model->updateMeta('some_key', 'New Value');
 $model->deleteMeta('some_key');
 $model->deleteAllMeta();

--- a/src/ScubaClick/Meta/MetaTrait.php
+++ b/src/ScubaClick/Meta/MetaTrait.php
@@ -20,7 +20,7 @@ trait MetaTrait
      *
      * @return Illuminate\Support\Collection
      */
-    public function getMeta($key, $getObj = false)
+    public function getMeta($key, $default = null, $getObj = false)
     {
         $meta = $this->meta()
             ->where('key', $key)
@@ -40,6 +40,10 @@ trait MetaTrait
             }
         }
 
+        // Were there no records? Return NULL if no default provided
+        if ($collection->count() == 0)
+            return $default;
+
         return $collection->count() <= 1 ? $collection->first() : $collection;
     }
 
@@ -50,7 +54,7 @@ trait MetaTrait
      */
     public function updateMeta($key, $newValue, $oldValue = false)
     {
-        $meta = $this->getMeta($key, true);
+        $meta = $this->getMeta($key, null, true);
 
         if ($meta == null)
         {
@@ -124,7 +128,7 @@ trait MetaTrait
     {
         if ($value)
         {
-            $meta = $this->getMeta($key, true);
+            $meta = $this->getMeta($key, null, true);
 
             if ($meta == null) return false;
 


### PR DESCRIPTION
In cases where getMeta() is used to find a meta key that may not exist, the use should be able to specify a default value to be returned. This is important for me because I allow third-party plugins to create meta fields, but there is no way to guarantee which fields may or may not exist.

```
$value = $meta->getMeta('key_doesnt_exist', 'Default Value');
```
returns 'Default Value'

I've forked and made a simple pull request, and yes, I took into account the $getObj argument.